### PR TITLE
Add possibility to get Bugzilla stats for third person

### DIFF
--- a/beaker_plugin.py
+++ b/beaker_plugin.py
@@ -27,8 +27,11 @@ def get_config(filename):
     return conf
 
 
-def get_metrics(start, end, config = None):
+def get_metrics(start, end, author = None, config = None):
     metrics = {}
+
+    if author:
+        print "Beaker plugin do not support --author option!"
 
     if config is None:
         config = get_config(os.environ['HOME'] + '/.qe-metrics/beaker.conf')

--- a/bugzilla_plugin.py
+++ b/bugzilla_plugin.py
@@ -25,7 +25,7 @@ def get_config(filename):
 
     return conf
 
-def get_metrics(start, end, config = None):
+def get_metrics(start, end, author = None, config = None):
     metrics = {}
 
     if config is None:
@@ -33,6 +33,9 @@ def get_metrics(start, end, config = None):
 
     user = config['username']
     password = config['password']
+
+    if not author:
+        author = user
 
     bz = bugzilla.Bugzilla(url='https://%s/xmlrpc.cgi' % config['url'])
     if not bz.login(user, password):
@@ -43,7 +46,7 @@ def get_metrics(start, end, config = None):
     qd = {
         'query_format' : 'advanced',
 
-        'reporter' : user,
+        'reporter' : author,
         'chfieldfrom' : start,
         'chfieldto' : end,
         'chfield' : '[Bug creation]',
@@ -66,7 +69,7 @@ def get_metrics(start, end, config = None):
 
         'field0-1-0' : 'bug_status',
         'type0-1-0' : 'changedby',
-        'value0-1-0' : user,
+        'value0-1-0' : author,
 
         'field0-2-0' : 'bug_status',
         'type0-2-0' : 'changedafter',
@@ -93,7 +96,7 @@ def get_metrics(start, end, config = None):
 
         'field0-1-0' : 'cf_verified',
         'type0-1-0' : 'changedby',
-        'value0-1-0' : user,
+        'value0-1-0' : author,
 
         'field0-2-0' : 'cf_verified',
         'type0-2-0' : 'changedafter',
@@ -121,7 +124,7 @@ def get_metrics(start, end, config = None):
 
         'field0-1-0' : 'bug_status',
         'type0-1-0' : 'changedby',
-        'value0-1-0' : user,
+        'value0-1-0' : author,
 
         'field0-2-0' : 'bug_status',
         'type0-2-0' : 'changedafter',
@@ -145,7 +148,7 @@ def get_metrics(start, end, config = None):
 
         'field0-0-0' : 'setters.login_name',
         'type0-0-0' : 'equals',
-        'value0-0-0' : user,
+        'value0-0-0' : author,
 
         'field0-1-0' : 'flagtypes.name',
         'type0-1-0' : 'changedto',
@@ -174,8 +177,9 @@ if __name__ == "__main__":
     from pprint import pprint
 
     p = optparse.OptionParser()
-    p.add_option('-s', '--start', dest="start", default=None, help="Start date: YYYY-MM-DD")
-    p.add_option('-e', '--end',   dest="end",   default=None, help="End date:   YYYY-MM-DD")
+    p.add_option('-s', '--start',  dest="start",  default=None, help="Start date: YYYY-MM-DD")
+    p.add_option('-e', '--end',    dest="end",    default=None, help="End date:   YYYY-MM-DD")
+    p.add_option('-a', '--author', dest="author", default=None, help="Author of the action. Defaults to yurself.")
 
     (opt, args) = p.parse_args()
 
@@ -193,7 +197,7 @@ if __name__ == "__main__":
     metrics =  {
         'start' : opt.start,
         'end'   : opt.end,
-        'bugzilla' : get_metrics(opt.start, opt.end),
+        'bugzilla' : get_metrics(opt.start, opt.end, opt.author),
     }
 
     pprint(metrics)

--- a/moinmoin_plugin.py
+++ b/moinmoin_plugin.py
@@ -27,8 +27,11 @@ def get_config(filename):
     return conf
 
 
-def get_metrics(start, end, config = None):
+def get_metrics(start, end, author = None, config = None):
     metrics = {}
+
+    if author:
+        print "MoinMoin plugin do not support --author option!"
 
     if config is None:
         config = get_config(os.environ['HOME'] + '/.qe-metrics/moinmoin.conf')

--- a/nitrate_plugin.py
+++ b/nitrate_plugin.py
@@ -5,8 +5,11 @@
 import os
 from nitrate_driver import NitrateXmlrpc
 
-def get_metrics(start, end):
+def get_metrics(start, end, author = None):
     metrics = {}
+
+    if author:
+        print "Nitrate plugin do not support --author option!"
 
     nitrate = NitrateXmlrpc.from_config(os.environ['HOME'] + '/.qe-metrics/nitrate.conf')
     user = nitrate.get_me()

--- a/qe-metrics
+++ b/qe-metrics
@@ -24,8 +24,9 @@ def import_file(filename):
 
 
 p = optparse.OptionParser()
-p.add_option('-s', '--start', dest="start", default=None, help="Start date: YYYY-MM-DD")
-p.add_option('-e', '--end',   dest="end",   default=None, help="End date:   YYYY-MM-DD")
+p.add_option('-s', '--start',  dest="start",  default=None, help="Start date: YYYY-MM-DD")
+p.add_option('-e', '--end',    dest="end",    default=None, help="End date:   YYYY-MM-DD")
+p.add_option('-a', '--author', dest="author", default=None, help="Author of the action. Defaults to yurself.")
 
 (opt, args) = p.parse_args()
 
@@ -43,6 +44,7 @@ opt.end = '%s 23:59:59' % opt.end
 metrics =  {
     'start' : opt.start,
     'end'   : opt.end,
+    'author': opt.author,
 }
 
 
@@ -65,7 +67,7 @@ for name in plugins.keys():
         plugin = import_file('%s_plugin.py' % name)
 
         print "INFO: Fetching metrics for %s" % name
-        metrics[name] = plugin.get_metrics(opt.start, opt.end)
+        metrics[name] = plugin.get_metrics(opt.start, opt.end, opt.author)
 
 
 pprint(metrics)

--- a/request_tracker_plugin.py
+++ b/request_tracker_plugin.py
@@ -40,8 +40,11 @@ class Response:
         self.contents = ''
 
 
-def get_metrics(start, end, config = None):
+def get_metrics(start, end, author = None, config = None):
     metrics = {}
+
+    if author:
+        print "Request Tracker plugin do not support --author option!"
 
     if config is None:
         config = get_config(os.environ['HOME'] + '/.qe-metrics/request_tracker.conf')


### PR DESCRIPTION
I have changed order of arguments of all get_metrics functions, but I have not noticed where "config" is used, so should not hurt.

I have only implemented the functionality in Bugzilla plugin.
